### PR TITLE
Add 276 claim status parser example

### DIFF
--- a/Parse276ClaimStatus/pom.xml
+++ b/Parse276ClaimStatus/pom.xml
@@ -27,6 +27,27 @@
             <version>2.1.0</version>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.38</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-xml</artifactId>
+            <version>2.19.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.19.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.36</version>

--- a/Parse276ClaimStatus/src/main/java/org/example/XML/X12_276_ClaimStatus.java
+++ b/Parse276ClaimStatus/src/main/java/org/example/XML/X12_276_ClaimStatus.java
@@ -1,0 +1,314 @@
+package org.example.XML;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.Data;
+
+/**
+ * Minimal Java representation of a 276 Claim Status message.
+ * <p>
+ * Only the segments used in the sample file are modeled.  This is just
+ * enough to demonstrate how Smooks can map the EDI message into Java
+ * objects using Jackson for the XML binding.
+ */
+@Data
+@JsonRootName("X12_276_ClaimStatus")
+public class X12_276_ClaimStatus {
+
+    @JsonProperty("interchange-header")
+    private InterchangeHeader interchangeHeader;
+
+    @JsonProperty("group-header")
+    private GroupHeader groupHeader;
+
+    @JsonProperty("transaction-set-header")
+    private TransactionSetHeader transactionSetHeader;
+
+    @JsonProperty("bht")
+    private Bht bht;
+
+    @JsonProperty("information-source")
+    private InformationSource informationSource;
+
+    @JsonProperty("information-receiver")
+    private InformationReceiver informationReceiver;
+
+    @JsonProperty("provider")
+    private Provider provider;
+
+    @JsonProperty("subscriber")
+    private Subscriber subscriber;
+
+    @JsonProperty("transaction-set-trailer")
+    private TransactionSetTrailer transactionSetTrailer;
+
+    @JsonProperty("functional-group-trailer")
+    private FunctionalGroupTrailer functionalGroupTrailer;
+
+    @JsonProperty("interchange-control-trailer")
+    private InterchangeControlTrailer interchangeControlTrailer;
+
+    // -------------------------------------------------------------
+    @Data
+    public static class InterchangeHeader {
+        @JsonProperty("auth-qual")
+        private String authQual;
+        @JsonProperty("auth-id")
+        private String authId;
+        @JsonProperty("security-qual")
+        private String securityQual;
+        @JsonProperty("security-id")
+        private String securityId;
+        @JsonProperty("sender-qual")
+        private String senderQual;
+        @JsonProperty("sender-id")
+        private String senderId;
+        @JsonProperty("receiver-qual")
+        private String receiverQual;
+        @JsonProperty("receiver-id")
+        private String receiverId;
+        @JsonProperty("date")
+        private String date;
+        @JsonProperty("time")
+        private String time;
+        @JsonProperty("standard")
+        private String standard;
+        @JsonProperty("version")
+        private String version;
+        @JsonProperty("interchange-control-number")
+        private String interchangeControlNumber;
+        @JsonProperty("ack")
+        private String ack;
+        @JsonProperty("test")
+        private String test;
+        @JsonProperty("s-delimiter")
+        private String sDelimiter;
+    }
+
+    @Data
+    public static class GroupHeader {
+        @JsonProperty("code")
+        private String code;
+        @JsonProperty("sender")
+        private String sender;
+        @JsonProperty("receiver")
+        private String receiver;
+        @JsonProperty("date")
+        private String date;
+        @JsonProperty("time")
+        private String time;
+        @JsonProperty("group-control-number")
+        private String groupControlNumber;
+        @JsonProperty("standard")
+        private String standard;
+        @JsonProperty("version")
+        private String version;
+    }
+
+    @Data
+    public static class TransactionSetHeader {
+        @JsonProperty("code")
+        private String code;
+        @JsonProperty("transaction-set-control-number")
+        private String transactionSetControlNumber;
+        @JsonProperty("implementation-convention")
+        private String implementationConvention;
+    }
+
+    @Data
+    public static class Bht {
+        @JsonProperty("hierarchical-structure-code")
+        private String hierarchicalStructureCode;
+        @JsonProperty("transaction-set-purpose-code")
+        private String transactionSetPurposeCode;
+        @JsonProperty("reference-identification")
+        private String referenceIdentification;
+        @JsonProperty("date")
+        private String date;
+        @JsonProperty("time")
+        private String time;
+    }
+
+    @Data
+    public static class Hl {
+        @JsonProperty("hierarchical-id-number")
+        private String hierarchicalIdNumber;
+        @JsonProperty("hierarchical-parent-id")
+        private String hierarchicalParentId;
+        @JsonProperty("hierarchical-level-code")
+        private String hierarchicalLevelCode;
+        @JsonProperty("hierarchical-child-code")
+        private String hierarchicalChildCode;
+    }
+
+    @Data
+    public static class Nm1 {
+        @JsonProperty("entity-id-code")
+        private String entityIdCode;
+        @JsonProperty("entity-type-qualifier")
+        private String entityTypeQualifier;
+        @JsonProperty("name-last-or-org")
+        private String nameLastOrOrg;
+        @JsonProperty("name-first")
+        private String nameFirst;
+        @JsonProperty("name-middle")
+        private String nameMiddle;
+        @JsonProperty("name-prefix")
+        private String namePrefix;
+        @JsonProperty("name-suffix")
+        private String nameSuffix;
+        @JsonProperty("id-code-qualifier")
+        private String idCodeQualifier;
+        @JsonProperty("id-code")
+        private String idCode;
+    }
+
+    @Data
+    public static class Per {
+        @JsonProperty("contact-function-code")
+        private String contactFunctionCode;
+        @JsonProperty("name")
+        private String name;
+        @JsonProperty("communication-number-qualifier")
+        private String communicationNumberQualifier;
+        @JsonProperty("communication-number")
+        private String communicationNumber;
+    }
+
+    @Data
+    public static class Trn {
+        @JsonProperty("trace-type-code")
+        private String traceTypeCode;
+        @JsonProperty("reference-identification")
+        private String referenceIdentification;
+        @JsonProperty("originating-company-id")
+        private String originatingCompanyId;
+        @JsonProperty("reference-id")
+        private String referenceId;
+    }
+
+    @Data
+    public static class Ref {
+        @JsonProperty("qualifier")
+        private String qualifier;
+        @JsonProperty("id")
+        private String id;
+    }
+
+    @Data
+    public static class N3 {
+        @JsonProperty("address1")
+        private String address1;
+        @JsonProperty("address2")
+        private String address2;
+    }
+
+    @Data
+    public static class N4 {
+        @JsonProperty("city")
+        private String city;
+        @JsonProperty("state")
+        private String state;
+        @JsonProperty("postal")
+        private String postal;
+    }
+
+    @Data
+    public static class Dmg {
+        @JsonProperty("format")
+        private String format;
+        @JsonProperty("date")
+        private String date;
+        @JsonProperty("gender")
+        private String gender;
+    }
+
+    @Data
+    public static class Dtp {
+        @JsonProperty("qualifier")
+        private String qualifier;
+        @JsonProperty("format")
+        private String format;
+        @JsonProperty("date")
+        private String date;
+    }
+
+    @Data
+    public static class Eq {
+        @JsonProperty("service-type-code")
+        private String serviceTypeCode;
+    }
+
+    // Loop groupings
+    @Data
+    public static class InformationSource {
+        @JsonProperty("hl")
+        private Hl hl;
+        @JsonProperty("nm1")
+        private Nm1 nm1;
+    }
+
+    @Data
+    public static class InformationReceiver {
+        @JsonProperty("hl")
+        private Hl hl;
+        @JsonProperty("nm1")
+        private Nm1 nm1;
+        @JsonProperty("per")
+        private Per per;
+    }
+
+    @Data
+    public static class Provider {
+        @JsonProperty("hl")
+        private Hl hl;
+        @JsonProperty("nm1")
+        private Nm1 nm1;
+        @JsonProperty("trn")
+        private Trn trn;
+    }
+
+    @Data
+    public static class Subscriber {
+        @JsonProperty("hl")
+        private Hl hl;
+        @JsonProperty("nm1")
+        private Nm1 nm1;
+        @JsonProperty("ref")
+        private Ref ref;
+        @JsonProperty("n3")
+        private N3 n3;
+        @JsonProperty("n4")
+        private N4 n4;
+        @JsonProperty("dmg")
+        private Dmg dmg;
+        @JsonProperty("dtp")
+        private Dtp dtp;
+        @JsonProperty("eq")
+        private Eq eq;
+    }
+
+    @Data
+    public static class TransactionSetTrailer {
+        @JsonProperty("number-of-included-segments")
+        private String numberOfIncludedSegments;
+        @JsonProperty("transaction-set-control-number")
+        private String transactionSetControlNumber;
+    }
+
+    @Data
+    public static class FunctionalGroupTrailer {
+        @JsonProperty("number-of-transaction-sets")
+        private String numberOfTransactionSets;
+        @JsonProperty("group-control-number")
+        private String groupControlNumber;
+    }
+
+    @Data
+    public static class InterchangeControlTrailer {
+        @JsonProperty("number-of-function-groups-included")
+        private String numberOfFunctionGroupsIncluded;
+        @JsonProperty("interchange-control-number")
+        private String interchangeControlNumber;
+    }
+}

--- a/Parse276ClaimStatus/src/main/java/org/example/XML/X12_276_Parser.java
+++ b/Parse276ClaimStatus/src/main/java/org/example/XML/X12_276_Parser.java
@@ -1,0 +1,76 @@
+package org.example.XML;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.smooks.FilterSettings;
+import org.smooks.Smooks;
+import org.smooks.io.sink.StringSink;
+import org.smooks.io.source.StreamSource;
+import org.xml.sax.SAXException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+/**
+ * Parser utilities for X12 276 Claim Status messages.
+ * <p>
+ * The implementation mirrors {@link X12_850_Parser} but targets the
+ * simplified {@link X12_276_ClaimStatus} model.
+ */
+@Slf4j
+public class X12_276_Parser {
+
+    private static final XmlMapper xmlMapper = new XmlMapper();
+    private static final JsonMapper jsonMapper = new JsonMapper();
+    private static final YAMLMapper yamlMapper = new YAMLMapper();
+
+    static {
+        xmlMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public static String parseEDI(String ediString) throws IOException, SAXException {
+        return parseEDI(ediString.getBytes());
+    }
+
+    public static String parseEDI(byte[] ediInput) throws IOException, SAXException {
+        StringSink result;
+        try (Smooks smooks = new Smooks("parse-config.xml")) {
+            result = new StringSink();
+            smooks.filterSource(new StreamSource<>(new ByteArrayInputStream(ediInput)), result);
+        }
+        return result.getResult();
+    }
+
+    public static X12_276_ClaimStatus parseXML(String xml) throws IOException {
+        return xmlMapper.readValue(xml, X12_276_ClaimStatus.class);
+    }
+
+    public static String toXml(X12_276_ClaimStatus claimStatus) throws IOException {
+        return xmlMapper.writeValueAsString(claimStatus);
+    }
+
+    public static String toJson(X12_276_ClaimStatus claimStatus) throws IOException {
+        return jsonMapper.writeValueAsString(claimStatus);
+    }
+
+    public static String toYaml(X12_276_ClaimStatus claimStatus) throws IOException {
+        return yamlMapper.writeValueAsString(claimStatus);
+    }
+
+    public static String xmlToEDI(String xml) throws IOException, SAXException {
+        StringSink result;
+        try (Smooks smooks = new Smooks("serialize-config.xml")) {
+            smooks.setFilterSettings(FilterSettings.newSaxNgSettings().setDefaultSerializationOn(false));
+            result = new StringSink();
+            smooks.filterSource(new StreamSource<>(new ByteArrayInputStream(xml.getBytes())), result);
+        }
+        return result.toString();
+    }
+
+    public static String xmlToEDI(X12_276_ClaimStatus claimStatus) throws IOException, SAXException {
+        return xmlToEDI(toXml(claimStatus));
+    }
+}

--- a/Parse276ClaimStatus/src/main/java/org/example/claimstatus/Main.java
+++ b/Parse276ClaimStatus/src/main/java/org/example/claimstatus/Main.java
@@ -1,78 +1,35 @@
 package org.example.claimstatus;
 
-import org.smooks.Smooks;
-import org.smooks.io.sink.StringSink;
-import org.smooks.io.source.StreamSource;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
+import lombok.extern.slf4j.Slf4j;
+import org.example.XML.X12_276_ClaimStatus;
+import org.example.XML.X12_276_Parser;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
 /**
- * Example program that parses an X12 276 Claim Status request using Smooks and
- * prints out the segment values.  The Smooks configuration relies on the
- * claimstatus276.xsd DFDL schema.
+ * Demonstrates parsing an X12 276 Claim Status request into Java objects using Smooks.
+ * <p>
+ * The program converts the EDI message to XML and then uses Jackson to bind the
+ * XML into the {@link X12_276_ClaimStatus} model.
  */
+@Slf4j
 public class Main {
 
     public static void main(String[] args) throws Exception {
         byte[] ediInput = Files.readAllBytes(Paths.get(Main.class.getClassLoader()
                 .getResource("input276.edi").toURI()));
 
-        // Convert the EDI message to XML using Smooks
-        String xml = parseEDI(ediInput);
+        // Convert EDI -> XML
+        String xml = X12_276_Parser.parseEDI(ediInput);
+        log.info("Parsed XML:\n{}", xml);
 
-        // Display the resulting XML
-        System.out.println("Parsed XML:\n" + xml);
+        // Map XML to Java object
+        X12_276_ClaimStatus claimStatus = X12_276_Parser.parseXML(xml);
+        log.info("Interchange control number: {}", claimStatus.getInterchangeHeader().getInterchangeControlNumber());
 
-        // Print each segment and its values
-        printSegments(xml);
-    }
-
-    /**
-     * Use Smooks to convert the EDI message into XML using the configuration in
-     * parse-config.xml.
-     */
-    private static String parseEDI(byte[] ediInput) throws IOException {
-        StringSink result;
-        try (Smooks smooks = new Smooks("parse-config.xml")) {
-            result = new StringSink();
-            smooks.filterSource(new StreamSource<>(new ByteArrayInputStream(ediInput)), result);
-        }
-        return result.getResult();
-    }
-
-    /**
-     * Parse the XML produced by Smooks and print each segment element and the
-     * values of its child elements.
-     */
-    private static void printSegments(String xml) throws Exception {
-        Document doc = DocumentBuilderFactory.newInstance()
-                .newDocumentBuilder()
-                .parse(new ByteArrayInputStream(xml.getBytes()));
-
-        Element root = doc.getDocumentElement();
-        NodeList segments = root.getChildNodes();
-        for (int i = 0; i < segments.getLength(); i++) {
-            Node seg = segments.item(i);
-            if (seg.getNodeType() != Node.ELEMENT_NODE) {
-                continue;
-            }
-            System.out.println("Segment: " + seg.getNodeName());
-            NodeList fields = seg.getChildNodes();
-            for (int j = 0; j < fields.getLength(); j++) {
-                Node f = fields.item(j);
-                if (f.getNodeType() != Node.ELEMENT_NODE) {
-                    continue;
-                }
-                System.out.println("  " + f.getNodeName() + " = " + f.getTextContent());
-            }
-        }
+        // Convert back to other formats
+        log.info("As JSON: {}", X12_276_Parser.toJson(claimStatus));
+        log.info("As YAML: {}", X12_276_Parser.toYaml(claimStatus));
     }
 }

--- a/Parse276ClaimStatus/src/main/resources/serialize-config.xml
+++ b/Parse276ClaimStatus/src/main/resources/serialize-config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<smooks-resource-list xmlns="https://www.smooks.org/xsd/smooks-2.0.xsd"
+        xmlns:edi="https://www.smooks.org/xsd/smooks/edi-2.0.xsd">
+
+    <edi:unparser unparseOnNode="*" schemaUri="claimstatus276.xsd"
+                  segmentTerminator="~" dataElementSeparator="*" validationMode="Full"/>
+</smooks-resource-list>


### PR DESCRIPTION
## Summary
- add POJOs for `X12_276_ClaimStatus`
- add `X12_276_Parser` with Smooks helpers
- update example `Main` to parse EDI to POJOs
- add Smooks serialize config and required dependencies

## Testing
- `mvn -q -DskipTests install` *(fails: Plugin resolution from Maven Central blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883b01d6970832aa0166ceca1d1c800